### PR TITLE
appinfo.json: Add requirePermissions for Enhanced ACG used on LuneOS

### DIFF
--- a/enyo-app/appinfo.json
+++ b/enyo-app/appinfo.json
@@ -9,5 +9,6 @@
 	"miniicon": "iconff-48.png",
 	"splashicon": "iconff-256.png",
 	"noWindow": "true",
-	"uiRevision": 2
+	"uiRevision": 2,
+	"requiredPermissions": ["appmanager.management", "powerd.management"]
 }


### PR DESCRIPTION
To allow access to the various calls by the app.

luna://com.palm.applicationManager/open, luna://com.palm.power/timeout/set and luna://com.palm.power/timeout/clear

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>