### PR TITLE
appinfo.json: Add further permissions for cordova

### DIFF
--- a/enyo-app/appinfo.json
+++ b/enyo-app/appinfo.json
@@ -10,5 +10,5 @@
 	"splashicon": "iconff-256.png",
 	"noWindow": "true",
 	"uiRevision": 2,
-	"requiredPermissions": ["appmanager.management", "powerd.management"]
+	"requiredPermissions": ["appmanager.management", "luna-sysmgr.operation", "networkconnection.query", "powerd.management", "preferences.system"]
 }


### PR DESCRIPTION
Cordova does various palm:// calls. Let's make sure we provide permissions for all of them.

palm://com.palm.preferences/systemProperties/Get

Required permission:
https://github.com/webosose/luna-prefs/blob/master/files/sysbus/com.palm.preferences.api.json#L11-L12

palm://com.palm.connectionmanager/getstatus

palm://com.palm.vibrate/vibrate

Required permissions:
https://github.com/webosose/webos-connman-adapter/blob/master/files/sysbus/webos-connman-adapter.api.json#L2-L6

Required permissions:
https://github.com/webOS-ports/luna-sysmgr/blob/herrie/enhanced-acg/files/sysbus/com.palm.luna.api.json#L2-L53